### PR TITLE
Fix `update-index` command argument

### DIFF
--- a/content/blog/ignoring-files-in-git-without-gitignore.md
+++ b/content/blog/ignoring-files-in-git-without-gitignore.md
@@ -42,8 +42,8 @@ So here’s the use-case that led me to write this blog-post. I was doing some c
 In this case, I used the following commands:
 
 ```
-git update-index —assume-unchanged app/config/local/database.php
-git update-index —assume-unchanged app/config/local/app.php
+git update-index --assume-unchanged app/config/local/database.php
+git update-index --assume-unchanged app/config/local/app.php
 ```
 
 With this, any changes in `app/config/local/database.php` or `app/config/local/app.php` will *not* show up in case I run `git status`.


### PR DESCRIPTION
I copied a command from https://luisdalmolin.dev/blog/ignoring-files-in-git-without-gitignore/ that was wrong and had a hard time finding what was wrong 😅 Not only it was missing a dash, but the one that was there was not a dash character.

Looks like it happened to others too https://stackoverflow.com/questions/18635405/git-update-index-assume-unchanged-error-assume-unchanged-does-not-exist-and
<img width="704" alt="image" src="https://github.com/user-attachments/assets/0d1ab8f2-cb32-4f05-908c-7f901a3fe0cd" />
